### PR TITLE
Cache contest infos and rating changes in memory.

### DIFF
--- a/carrot/background.js
+++ b/carrot/background.js
@@ -1,80 +1,115 @@
 import * as api from './cf-api.js';
-import * as settings from './settings.js';
 import * as store from './storage.js';
 import { Contestant, predict } from './predict.js';
+import { Contests } from './contests.js';
+import { RatingChanges } from './rating-changes.js';
+import { UserPrefs } from './user-prefs.js';
 
 const DEFAULT_RATING = 1500;
 const UNRATED_HINTS = ['unrated', 'fools', 'q#', 'kotlin', 'marathon', 'team'];
 const EDU_ROUND_RATED_THRESHOLD = 2100;
 const RATING_PENDING_MAX_DAYS = 3;
 
-browser.runtime.onMessage.addListener(listener);
+let CONTESTS;
+let RATING_CHANGES;
+
+function main() {
+  CONTESTS = new Contests(api);
+  RATING_CHANGES = new RatingChanges(api);
+  browser.runtime.onMessage.addListener(listener);
+}
 
 function listener(message) {
   return getDeltas(message.contestId);
 }
 
-function probablyUnrated(contest, rows) {
-  const lower = contest.name.toLowerCase();
-  return (UNRATED_HINTS.some(hint => lower.includes(hint))
-    || rows.some(row => row.party.teamId != null || row.party.teamName != null));
+function checkRatedByName(contestName) {
+  const lower = contestName.toLowerCase();
+  if (UNRATED_HINTS.some(hint => lower.includes(hint))) {
+    throw new Error('UNRATED_CONTEST');
+  }
 }
 
-function getRating(ratingMap, handle) {
-  return ratingMap[handle] != null ? ratingMap[handle] : DEFAULT_RATING;
+function checkRatedByTeam(rows) {
+  if (rows.some(row => row.party.teamId != null || row.party.teamName != null)) {
+    throw new Error('UNRATED_CONTEST');
+  }
+}
+
+function isOldContest(contest) {
+  const daysSinceContestEnd =
+    (Date.now() / 1000 - contest.startTimeSeconds - contest.durationSeconds) / (60 * 60 * 24);
+  return daysSinceContestEnd > RATING_PENDING_MAX_DAYS;
 }
 
 async function getDeltas(contestId) {
-  const showForRunning = await settings.showDeltasForRunning();
-  const showForFinished = await settings.showDeltasForFinished();
-  if (!showForRunning && !showForFinished) {
-    throw new Error('DISABLED');
+  const prefs = await UserPrefs.create();
+  prefs.checkEnabledForAny();
+
+  // If rating changes are cached, return them.
+  if (RATING_CHANGES.hasCached(contestId)) {
+    prefs.checkEnabledForFinished();
+    return await getDeltasForFinished(contestId);
   }
-  let { contest, _problems, rows } = await api.contest.standings(contestId);
-  if (probablyUnrated(contest, rows)) {
-    throw new Error('UNRATED_CONTEST');
-  }
-  if (contest.phase == 'FINISHED') {
-    if (!showForFinished) {
-      throw new Error('DISABLED');
+
+  // If the contest is old, get rating changes and don't try to predict.
+  if (CONTESTS.hasCached(contestId)) {
+    const contest = CONTESTS.get(contestId);
+    checkRatedByName(contest.name);
+    if (isOldContest(contest)) {
+      prefs.checkEnabledForFinished();
+      return await getDeltasForFinished(contestId);
     }
+  }
+
+  // The contest
+  // 1. does not have rating changes cached, and
+  // 2. either
+  //     a. does not exist in the contest cache, or
+  //     b. exists in the contest cache but is not an old contest.
+  //
+  // Try to get rating changes if the contest is finished else predict.
+
+  const { contest, problems_, rows} = await api.contest.standings(contestId);
+  CONTESTS.update(contest);
+  checkRatedByName(contest.name);
+  checkRatedByTeam(rows);
+
+  if (contest.phase == 'FINISHED') {
     try {
-      return getDeltasForFinished(contest);
+      const deltas = await getDeltasForFinished(contestId);
+      prefs.checkEnabledForFinished();
+      return deltas;
     } catch (er) {
-      if (er.message == 'RECENT_CONTEST') {
-        // Recent contest without rating changes, continue and predict.
+      if (er.message == 'UNRATED_CONTEST') {
+        // Not an old contest but missing rating changes, proceed to predict.
       } else {
         throw er;
       }
     }
   }
-  if (!showForRunning) {
-    throw new Error('DISABLED');
-  }
+  prefs.checkEnabledForRunning();
   return getDeltasForRunning(contest, rows);
 }
 
-async function getDeltasForFinished(contest) {
-  let ratingChanges;
+async function getDeltasForFinished(contestId) {
   try {
-    ratingChanges = await api.contest.ratingChanges(contest.id);
+    const ratingChanges = await RATING_CHANGES.fetch(contestId);
+    if (ratingChanges && ratingChanges.length) {
+      let deltas = {};
+      for (const change of ratingChanges) {
+        deltas[change.handle] = change.newRating - change.oldRating;
+      }
+      return { deltas: deltas, type: 'FINAL' };
+    }
   } catch (er) {
     console.error('Error fetching deltas: ' + er);
-  }
-  if (ratingChanges && ratingChanges.length) {
-    let deltas = {};
-    for (const change of ratingChanges) {
-      deltas[change.handle] = change.newRating - change.oldRating;
-    }
-    return { deltas: deltas, type: 'FINAL' };
-  }
-  const daysSinceContestEnd =
-    (Date.now() / 1000 - contest.startTimeSeconds - contest.durationSeconds) / (60 * 60 * 24);
-  if (daysSinceContestEnd > RATING_PENDING_MAX_DAYS) {
-    // Old contest and no rating changes, assume unrated.
     throw new Error('UNRATED_CONTEST');
   }
-  throw new Error('RECENT_CONTEST');
+}
+
+function getRating(ratingMap, handle) {
+  return ratingMap[handle] != null ? ratingMap[handle] : DEFAULT_RATING;
 }
 
 async function getDeltasForRunning(contest, rows) {
@@ -105,3 +140,5 @@ async function getUpdatedRatings(startTimeSec) {
   }
   return store.getRatings();
 }
+
+main();

--- a/carrot/cf-api.js
+++ b/carrot/cf-api.js
@@ -21,6 +21,10 @@ async function apiFetch(path, queryParams) {
 }
 
 const contest = {};
+contest.list = async function(gym) {
+  return await apiFetch('contest.list', { gym: gym });
+}
+
 contest.standings = async function(contestId, from, count, handles, room, showUnofficial) {
   return await apiFetch('contest.standings', {
     contestId: contestId,

--- a/carrot/contests.js
+++ b/carrot/contests.js
@@ -1,0 +1,40 @@
+const REFRESH_INTERVAL = 60 * 60 * 1000;  // 1 hour
+
+/**
+ * In-memory cache of contest infos.
+ */
+class Contests {
+  constructor(api) {
+    this.api = api;
+    this.contestMap = {};
+    this.refresh();
+  }
+
+  async refresh() {
+    try {
+      const contests = await this.api.contest.list();
+      const contestMap = {};
+      for (const c of contests) {
+        contestMap[c.id] = c;
+      }
+      this.contestMap = contestMap;
+    } catch (er) {
+      console.warn('Unable to fetch contest list: ' + er);
+    }
+    setTimeout(this.refresh, REFRESH_INTERVAL);
+  }
+
+  hasCached(contestId) {
+    return contestId in this.contestMap;
+  }
+
+  get(contestId) {
+    return this.contestMap[contestId];
+  }
+
+  update(contest) {
+    this.contestMap[contest.id] = contest;
+  }
+}
+
+export { Contests };

--- a/carrot/manifest.json
+++ b/carrot/manifest.json
@@ -12,7 +12,8 @@
     "storage"
   ],
   "background": {
-    "page": "background.html"
+    "page": "background.html",
+    "persistent": true
   },
   "content_scripts": [
     {

--- a/carrot/rating-changes.js
+++ b/carrot/rating-changes.js
@@ -1,0 +1,39 @@
+const MAX_CONTESTS = 15;
+
+/**
+ * In memory cache of rating changes that holds rating changes for at most MAX_CONTESTS contests.
+ */
+class RatingChanges {
+  constructor(api) {
+    this.api = api;
+    this.contestIds = [];
+    this.ratingChangesMap = {};
+  }
+
+  hasCached(contestId) {
+    return contestId in this.ratingChangesMap;
+  }
+
+  async fetch(contestId) {
+    if (this.hasCached(contestId)) {
+      return this.ratingChangesMap[contestId];
+    }
+    try {
+      const ratingChanges = await this.api.contest.ratingChanges(contestId);
+      this.contestIds.push(contestId);
+      this.ratingChangesMap[contestId] = ratingChanges;
+      if (this.contestIds.length > MAX_CONTESTS) {
+        delete this.ratingChangesMap[this.contestIds[0]];
+        this.contestIds.shift();
+      }
+      return ratingChanges;
+    } catch (er) {
+      // There is no way to determine if the contest is running or unrated or some other error
+      // occured, because the error is always a CORS network error. See cf-api.js for details.
+      // TODO: Fix this when CF API is fixed.
+      throw er;
+    }
+  }
+}
+
+export { RatingChanges };

--- a/carrot/user-prefs.js
+++ b/carrot/user-prefs.js
@@ -1,0 +1,33 @@
+import * as settings from './settings.js';
+
+class UserPrefs {
+  constructor(enabledForRunning, enabledForFinished) {
+    this.enabledForRunning = enabledForRunning;
+    this.enabledForFinished = enabledForFinished;
+  }
+
+  static async create() {
+    return new UserPrefs(
+      await settings.showDeltasForRunning(), await settings.showDeltasForFinished());
+  }
+
+  checkEnabledForRunning() {
+    if (!this.enabledForRunning) {
+      throw new Error('DISABLED');
+    }
+  }
+
+  checkEnabledForFinished() {
+    if (!this.enabledForFinished) {
+      throw new Error('DISABLED');
+    }
+  }
+
+  checkEnabledForAny() {
+    if (!this.enabledForRunning && !this.enabledForFinished) {
+      throw new Error('DISABLED');
+    }
+  }
+}
+
+export { UserPrefs };


### PR DESCRIPTION
- Caching contest infos helps save a call to contest.standings if the
  contest is old in which case we don't want to predict.
- Caching rating changes prevents hitting contest.ratingChanges
  repeatedly for the same contest.
Not caching them in storage because they are not that heavy.