### PR TITLE
Increase cache time to 30s

### DIFF
--- a/carrot/src/background/predict-response.js
+++ b/carrot/src/background/predict-response.js
@@ -15,10 +15,11 @@ class PredictResponseRow {
 }
 
 class PredictResponse {
-  constructor(predictResults, type) {
+  constructor(predictResults, type, fetchTime) {
     PredictResponse.assertTypeOk(type);
     this.rowMap = {};
     this.type = type;
+    this.fetchTime = fetchTime;
     this.populateMap(predictResults);
   }
 

--- a/carrot/src/background/top-level-cache.js
+++ b/carrot/src/background/top-level-cache.js
@@ -1,4 +1,4 @@
-const TIMEOUT = 15 * 1000;  // 15 seconds
+const TIMEOUT = 30 * 1000;  // 30 seconds
 
 /**
  * Short time cache on the response to a prediction request.

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -209,17 +209,16 @@ function showFinal() {
   document.querySelector(`#${PREDICT_TEXT_ID}`).textContent = 'Final';
 }
 
-function showTimer() {
+function showTimer(fetchTime) {
   const predictTextSpan = document.querySelector(`#${PREDICT_TEXT_ID}`);
-  const predictedAt = Date.now();
   function update() {
-    const secSinceLastPredict = Math.floor((Date.now() - predictedAt) / 1000);
-    if (secSinceLastPredict < 20) {
+    const secSincePredict = Math.floor((Date.now() - fetchTime) / 1000);
+    if (secSincePredict < 20) {
       predictTextSpan.textContent = 'Just now';
-    } else if (secSinceLastPredict < 60) {
+    } else if (secSincePredict < 60) {
       predictTextSpan.textContent = '<1m old';
     } else {
-      predictTextSpan.textContent = Math.floor(secSinceLastPredict / 60) + 'm old';
+      predictTextSpan.textContent = Math.floor(secSincePredict / 60) + 'm old';
     }
   }
   update();
@@ -250,7 +249,7 @@ async function predict(contestId) {
       showFinal();
       break;
     case 'PREDICTED':
-      showTimer();
+      showTimer(resp.fetchTime);
       break;
     default:
       throw new Error('Unknown prediction type: ' + resp.type);

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -213,7 +213,7 @@ function showTimer(fetchTime) {
   const predictTextSpan = document.querySelector(`#${PREDICT_TEXT_ID}`);
   function update() {
     const secSincePredict = Math.floor((Date.now() - fetchTime) / 1000);
-    if (secSincePredict < 20) {
+    if (secSincePredict < 30) {
       predictTextSpan.textContent = 'Just now';
     } else if (secSincePredict < 60) {
       predictTextSpan.textContent = '<1m old';


### PR DESCRIPTION
Sometimes you're just going through pages and it expires, making the next page's predictions seem slow.