### PR TITLE
New system

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Carrot runs in the browser and fetches all the data it needs from the [Codeforce
 It then calculates the rating changes following the algorithm published by Mike Mirzayanov [here](https://codeforces.com/blog/entry/20762), slightly modified so that it matches the current CF algorithm. This updated algorithm is adapted from [TLE](https://github.com/cheran-senthil/TLE/blob/master/tle/util/ranklist/rating_calculator.py).
 
 #### Is this better than [CF-Predictor](https://codeforces.com/blog/entry/50411)?
-Not necessarily. The CF-Predictor extension communicates with a server, while Carrot fetches data and performs all calculations in the browser. So the network usage is significantly lower for CF-Predictor. However, Carrot is 100% accurate and it works in real time.
+Not necessarily. The CF-Predictor extension communicates with a server, while Carrot fetches data and performs all calculations in the browser. So the network usage is significantly lower for CF-Predictor. However, Carrot is ~~100% accurate~~(see [#18](https://github.com/meooow25/carrot/pull/18)) and it works in real time.
 
 #### How is Carrot fast enough to calculate rating changes of every contestant in real time?
 FFT. The answer is always FFT.

--- a/carrot/src/background/predict-response.js
+++ b/carrot/src/background/predict-response.js
@@ -35,9 +35,9 @@ export default class PredictResponse {
           break;
         case PredictResponse.TYPE_FINAL:
           // For an unrated user, user info has missing rating but if the user participates, the
-          // oldRating on the ratingChange object is set as 1500. So, for FINAL, at the moment
-          // rating = effectiveRating always, but keeping the code which works for unrated too, as
-          // things should be.
+          // oldRating on the ratingChange object is set as the default starting value. So, for
+          // FINAL, at the moment rating = effectiveRating always, but keeping the code which works
+          // for unrated too, as things should be.
           rank = Rank.forRating(result.rating);
           newRank = Rank.forRating(result.effectiveRating + result.delta);
           break;

--- a/carrot/src/background/predict.js
+++ b/carrot/src/background/predict.js
@@ -10,7 +10,7 @@ import FFTConv from '../util/conv.js';
  */
 
 const PRINT_PERFORMANCE = false;
-const DEFAULT_RATING = 1500;
+const DEFAULT_RATING = 1400;
 
 export class Contestant {
   constructor(party, points, penalty, rating) {

--- a/carrot/tests/compare.ts
+++ b/carrot/tests/compare.ts
@@ -1,0 +1,53 @@
+import * as api from '../src/background/cf-api.js';
+import predict, { Contestant } from '../src/background/predict.js';
+
+async function main() {
+  const contestId = Deno.args[0];
+  if (!contestId || isNaN(parseInt(contestId))) {
+    console.error('Missing or bad contest ID');
+    return;
+  }
+
+  console.info('Contest ' + contestId);
+  console.info('Fetching rating changes...');
+  const ratingChanges = await api.contest.ratingChanges(contestId);
+  if (ratingChanges.length) {
+    console.log('  Fetched ' + ratingChanges.length + ' rating changes');
+  } else {
+    console.error('Empty rating change list');
+    return;
+  }
+
+  const rating = Object.fromEntries(
+    ratingChanges.map((r: any) => [r.handle, { old: r.oldRating, new: r.newRating }]));
+
+  console.info('Fetching standings...');
+  let { contest_, problems_, rows } = await api.contest.standings(contestId);
+  console.info('  Fetched ' + rows.length + ' rows');
+  rows = rows.filter((row: any) => row.party.members[0].handle in rating);
+  console.info('  ' + rows.length + ' rows retained from rating change list');
+
+  console.info('Calculating deltas...');
+  const contestants = rows.map((row: any) => {
+    const handle = row.party.members[0].handle;
+    return new Contestant(handle, row.points, row.penalty, rating[handle].old);
+  });
+  const predictResults = predict(contestants);
+
+  const diffs = [];
+  for (const res of predictResults) {
+    const actualDelta = rating[res.handle].new - rating[res.handle].old;
+    if (res.delta != actualDelta) {
+      diffs.push([res.handle, rating[res.handle].old, actualDelta, res.delta]);
+    }
+  }
+  if (diffs.length) {
+    console.error(`Delta mismatch for ${diffs.length} contestants:`);
+    console.error('[handle, old rating, actual delta, calculated delta]');
+    console.error(diffs);
+  } else {
+    console.info('OK all match');
+  }
+}
+
+main();

--- a/carrot/tests/compare.ts
+++ b/carrot/tests/compare.ts
@@ -1,5 +1,13 @@
+import * as colors from 'https://deno.land/std/fmt/colors.ts';
 import * as api from '../src/background/cf-api.js';
 import predict, { Contestant } from '../src/background/predict.js';
+
+/**
+ * Compares actual vs calculated rating changes for a given finished rated contest.
+ * Matches upto Educational round 87 (1354). New rating system was imposed after that.
+ * 
+ * $ deno run --allow-net compare.ts <contest-id>
+ */
 
 async function main() {
   const contestId = Deno.args[0];
@@ -42,11 +50,16 @@ async function main() {
     }
   }
   if (diffs.length) {
-    console.error(`Delta mismatch for ${diffs.length} contestants:`);
-    console.error('[handle, old rating, actual delta, calculated delta]');
-    console.error(diffs);
+    console.error(colors.red(`Delta mismatch for ${diffs.length} contestants:`));
+    console.error(colors.red('[handle, old rating, actual delta, calculated delta]'));
+    for (const row of diffs.slice(0, 5)) {
+      console.error(colors.red('[' + row.join(', ') + ']'));
+    }
+    if (diffs.length > 5) {
+      console.log(colors.red(`...and ${diffs.length - 5} more`));
+    }
   } else {
-    console.info('OK all match');
+    console.info(colors.green('OK all match'));
   }
 }
 

--- a/carrot/tests/test-predict.ts
+++ b/carrot/tests/test-predict.ts
@@ -19,13 +19,13 @@ function predictedDeltas(data: TestDataRow[]): object {
 
 Deno.test('predict_ok', (): void => {
   const data: TestDataRow[] = [
-    ['bigbrain', 4000, 10, 3000, -237],
-    ['smartguy', 2500, 50, 2400, -175],
-    ['ordinaryguy', 1500, 80, 1800, -35],
-    ['brick', -100, 300, 500, -50],
-    ['alt', 5000, 0, undefined, 514],
-    ['luckyguy', 2500, 40, 1800, 121],
-    ['unluckyguy', 800, 40, 2000, -145],
+    ['bigbrain', 4000, 10, 3000, -241],
+    ['smartguy', 2500, 50, 2400, -181],
+    ['ordinaryguy', 1500, 80, 1800, -48],
+    ['brick', -100, 300, 500, -54],
+    ['alt', 5000, 0, undefined, 553],
+    ['luckyguy', 2500, 40, 1800, 118],
+    ['unluckyguy', 800, 40, 2000, -160],
   ];
 
   assertEquals(predictedDeltas(data), expectedDeltas(data));


### PR DESCRIPTION
There has been a change in the rating system of Codeforces ([blog here](https://codeforces.com/blog/entry/77890)).

Summary:
- The default rating for new accounts is now 1400 instead of 1500.
- The real rating is now hidden. Instead, a fake rating is shown which is `realRating - f(numRatedContestParticipations)` where the values of the function `f` at `0, 1, ...` are `[1400, 900, 550, 300, 150, 50, 0, 0, ...]`.

This PR updates the default value to 1400, but cannot deal with the second change.

The problem:
-  The real rating is not available through the API. [Mike said he will make this available](https://codeforces.com/blog/entry/77890?#comment-628777) but it has been 2 weeks since and there has been no update to the API.
The only way to calculate real ratings of users for the purpose of rating calculation is to *calculate the complete rating history of every user to ever participate in any Codeforces contest*, which is not a suitable task for an extension.
- Assuming Mike miraculously keeps his word it is possible to predict real ratings, but still impossible to predict the change to the displayed rating since it depends on `numRatedContestParticipations`. Since this number is not conveniently available through any API endpoint, the alternate is to *either query each individual user's rating history for every participant or query the rating changes for every contest on Codeforces ever*, both of which are again not suitable tasks for an extension.

**TL;DR: The Codeforces API is severely lacking and this recent change makes it impossible to predict rating changes accurately without calculating the entire rating history of Codeforces to find current ratings of participants in a contest.**