### PR TITLE
Speed tests up

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -2,20 +2,15 @@ name: Deno CI
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches: [ tests ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        filter: ['/^(?!perf)/', '/perf.*(1305|1326|1342)/', '/perf.*(1349|1350|1352)/']
     steps:
     - uses: actions/checkout@v2
     - uses: denolib/setup-deno@master
       with:
         deno-version: v1.x
     - name: Run tests
-      run: deno test --allow-read --filter '${{ matrix.filter }}' carrot/tests/test-*.ts
+      run: deno test --allow-read --filter 1349 carrot/tests/test-perf.ts

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -13,4 +13,4 @@ jobs:
       with:
         deno-version: v1.x
     - name: Run tests
-      run: deno test --allow-read --filter 1349 carrot/tests/test-perf.ts
+      run: deno test --allow-read --filter 1305 carrot/tests/test-perf.ts

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -2,15 +2,20 @@ name: Deno CI
 
 on:
   push:
-    branches: [ tests ]
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        filter: ['/^(?!perf)/', '/perf.*(1305|1326)/', '/perf.*(1342|1349)/', '/perf.*(1350|1352)/']
     steps:
     - uses: actions/checkout@v2
     - uses: denolib/setup-deno@master
       with:
         deno-version: v1.x
     - name: Run tests
-      run: deno test --allow-read --filter 1305 carrot/tests/test-perf.ts
+      run: deno test --allow-read --filter '${{ matrix.filter }}' carrot/tests/test-*.ts

--- a/carrot/tests/perf-worker.ts
+++ b/carrot/tests/perf-worker.ts
@@ -22,7 +22,6 @@ self.onmessage = (e: MessageEvent): void => {
       continue;
     }
     const result: Record<string, any> = {
-      constestant: c,
       fastPerf,
       deltaAtFastPerf:
           fastPerf == 'Infinity' ? c.rank == 1 ? 0 : '-Infinity' : calcDelta(c, fastPerf),

--- a/carrot/tests/test-perf.ts
+++ b/carrot/tests/test-perf.ts
@@ -6,7 +6,7 @@ import { RoundData, readTestData, dataRowsToContestants } from './rounds.ts';
 import { assertEquals, assertArrayContains } from './asserts.ts';
 
 // Increase to go fast, if you have the cores.
-const NUM_WORKERS = 2;
+const NUM_WORKERS = 1;
 const WORKER_SRC = './perf-worker.ts';
 
 // Deltas calculated with fast perf are usually 0, rarely -1, never worse than that.

--- a/carrot/tests/test-perf.ts
+++ b/carrot/tests/test-perf.ts
@@ -6,7 +6,7 @@ import { RoundData, readTestData, dataRowsToContestants } from './rounds.ts';
 import { assertEquals, assertArrayContains } from './asserts.ts';
 
 // Increase to go fast, if you have the cores.
-const NUM_WORKERS = 4;
+const NUM_WORKERS = 6;
 const WORKER_SRC = './perf-worker.ts';
 
 // Deltas calculated with fast perf are usually 0, rarely -1, never worse than that.

--- a/carrot/tests/test-perf.ts
+++ b/carrot/tests/test-perf.ts
@@ -6,7 +6,7 @@ import { RoundData, readTestData, dataRowsToContestants } from './rounds.ts';
 import { assertEquals, assertArrayContains } from './asserts.ts';
 
 // Increase to go fast, if you have the cores.
-const NUM_WORKERS = 6;
+const NUM_WORKERS = 4;
 const WORKER_SRC = './perf-worker.ts';
 
 // Deltas calculated with fast perf are usually 0, rarely -1, never worse than that.

--- a/carrot/tests/test-perf.ts
+++ b/carrot/tests/test-perf.ts
@@ -6,7 +6,7 @@ import { RoundData, readTestData, dataRowsToContestants } from './rounds.ts';
 import { assertEquals, assertArrayContains } from './asserts.ts';
 
 // Increase to go fast, if you have the cores.
-const NUM_WORKERS = 1;
+const NUM_WORKERS = 4;
 const WORKER_SRC = './perf-worker.ts';
 
 // Deltas calculated with fast perf are usually 0, rarely -1, never worse than that.

--- a/carrot/tests/test-perf.ts
+++ b/carrot/tests/test-perf.ts
@@ -6,7 +6,7 @@ import { RoundData, readTestData, dataRowsToContestants } from './rounds.ts';
 import { assertEquals, assertArrayContains } from './asserts.ts';
 
 // Increase to go fast, if you have the cores.
-const NUM_WORKERS = 4;
+const NUM_WORKERS = 1;
 const WORKER_SRC = './perf-worker.ts';
 
 // Deltas calculated with fast perf are usually 0, rarely -1, never worse than that.

--- a/carrot/tests/test-perf.ts
+++ b/carrot/tests/test-perf.ts
@@ -6,7 +6,7 @@ import { RoundData, readTestData, dataRowsToContestants } from './rounds.ts';
 import { assertEquals, assertArrayContains } from './asserts.ts';
 
 // Increase to go fast, if you have the cores.
-const NUM_WORKERS = 1;
+const NUM_WORKERS = 2;
 const WORKER_SRC = './perf-worker.ts';
 
 // Deltas calculated with fast perf are usually 0, rarely -1, never worse than that.

--- a/carrot/tests/test-perf.ts
+++ b/carrot/tests/test-perf.ts
@@ -6,7 +6,7 @@ import { RoundData, readTestData, dataRowsToContestants } from './rounds.ts';
 import { assertEquals, assertArrayContains } from './asserts.ts';
 
 // Increase to go fast, if you have the cores.
-const NUM_WORKERS = 2;
+const NUM_WORKERS = 4;
 const WORKER_SRC = './perf-worker.ts';
 
 // Deltas calculated with fast perf are usually 0, rarely -1, never worse than that.


### PR DESCRIPTION
- Performance on Github actions doesn't suffer with more workers, set to 4.
- Split into 3 runs.
- Don't send back contestant, has a minor effect on speed, more of a cleanup.
