### PR TITLE
Add permission to fix rating store error

### DIFF
--- a/carrot/manifest.json
+++ b/carrot/manifest.json
@@ -9,7 +9,8 @@
     "128": "icons/icon.svg"
   },
   "permissions": [
-    "storage"
+    "storage",
+    "unlimitedStorage"
   ],
   "background": {
     "page": "src/background/background.html",

--- a/carrot/src/background/background.js
+++ b/carrot/src/background/background.js
@@ -175,3 +175,11 @@ async function maybeUpdateRatings() {
 }
 
 // Cache related code ends.
+
+browser.runtime.onInstalled.addListener((details) => {
+  if (details.previousVersion == '0.6.2') {
+    // Clear cache to remove stale timestamp
+    // https://github.com/meooow25/carrot/issues/31
+    browser.storage.local.clear();
+  }
+});

--- a/carrot/src/background/cache/ratings.js
+++ b/carrot/src/background/cache/ratings.js
@@ -50,9 +50,8 @@ export default class Ratings {
 
   async cacheRatings() {
     const users = await this.api.user.ratedList(false);
-    // Save as object, saving as list of pairs goes over Chrome's 5MB local limit.
     const ratings = Object.fromEntries(users.map((u) => [u.handle, u.rating]));
-    await this.storage.set(RATINGS_TIMESTAMP, Date.now());
     await this.storage.set(RATINGS, ratings);
+    await this.storage.set(RATINGS_TIMESTAMP, Date.now());
   }
 }

--- a/carrot/src/background/cache/ratings.js
+++ b/carrot/src/background/cache/ratings.js
@@ -9,8 +9,8 @@ const RATINGS = 'cache.ratings';
  * Browser storage cache of user ratings. Ratings of all users are cached because user.info API
  * endpoint does not work with a large number of handles which is required for prediction. Browser
  * storage is used so that the data is retained if the user restarts the browser. The amount of
- * data fetched is around 14MB so we would rather not refetch it. We keep only handles and ratings
- * in storage, which uses around 4MB.
+ * data fetched is around 18MB so we would rather not refetch it. We keep only handles and ratings
+ * in storage, which uses around 5MB.
  */
 export default class Ratings {
   constructor(api, storage) {

--- a/carrot/src/options/options.html
+++ b/carrot/src/options/options.html
@@ -18,7 +18,7 @@
                 TL;DR: Disable this if you are on a data capped network
               </summary>
               If you are on Codeforces and a contest starts in less than an hour, having this
-              option enabled will prefetch user ratings (around 14MB of data) which is required for
+              option enabled will prefetch user ratings (around 18MB of data) which is required for
               delta prediction. This is a one-time fetch for the contest. Disabling this will fetch
               the ratings when you open the ranklist for the first time.
             </details>


### PR DESCRIPTION
Bug fix for a Chrome-only issue where prediction for an active contest is broken or uses outdated ratings.

Chrome has a local storage limit of 5MB, which the map of ~31,000 user ratings now exceeds.
Adding `"unlimitedStorage"` permission fixes this.

As a side note, storage would not be necessary if CF API followed its own documented behavior ([issue](https://codeforces.com/blog/entry/74558)).

Fixes #31.