### PR TITLE
Don't cache finished contests during magic

### DIFF
--- a/carrot/src/background/cache/contests-complete.js
+++ b/carrot/src/background/cache/contests-complete.js
@@ -79,6 +79,8 @@ export class ContestsComplete {
     // If the contest is finished, the contest data doesn't change so cache it.
     // The exception is during new year's magic, when people change handles and handles on the
     // ranklist can become outdated.
+    // TODO: New users can also change handles upto a week(?) after joining. Is this a big enough
+    // issue to stop caching at all?
     if (isFinished && !isMagicOn()) {
       this.contests.set(contestId, c);
       this.contestIds.push(contestId);

--- a/carrot/src/background/cache/contests-complete.js
+++ b/carrot/src/background/cache/contests-complete.js
@@ -80,7 +80,7 @@ export class ContestsComplete {
     // The exception is during new year's magic, when people change handles and handles on the
     // ranklist can become outdated.
     // TODO: New users can also change handles upto a week(?) after joining. Is this a big enough
-    // issue to stop caching at all?
+    // issue to stop caching completely?
     if (isFinished && !isMagicOn()) {
       this.contests.set(contestId, c);
       this.contestIds.push(contestId);

--- a/carrot/src/background/cache/contests-complete.js
+++ b/carrot/src/background/cache/contests-complete.js
@@ -27,6 +27,14 @@ function isOldContest(contest) {
   return daysSinceContestEnd > RATING_PENDING_MAX_DAYS;
 }
 
+function isMagicOn() {
+  let now = new Date();
+  // Magic typically lasts 1 Jan to 10 Jan, but let's put some buffer and assume it happens from
+  // 30 Dec to 11 Jan.
+  return now.getMonth() === 11 && now.getDate() >= 30
+      || now.getMonth() === 0 && now.getDate() <= 11;
+}
+
 const MAX_FINISHED_CONTESTS_TO_CACHE = 15;
 
 /**
@@ -67,7 +75,11 @@ export class ContestsComplete {
     const isFinished = isRated === Contest.IsRated.NO || isRated === Contest.IsRated.YES;
 
     const c = new Contest(contest, problems, rows, ratingChanges, Date.now(), isRated);
-    if (isFinished) {
+
+    // If the contest is finished, the contest data doesn't change so cache it.
+    // The exception is during new year's magic, when people change handles and handles on the
+    // ranklist can become outdated.
+    if (isFinished && !isMagicOn()) {
       this.contests.set(contestId, c);
       this.contestIds.push(contestId);
       if (this.contestIds.length > MAX_FINISHED_CONTESTS_TO_CACHE) {


### PR DESCRIPTION
Users change handles during magic, so cached ranklists can end up containing outdated handles.

Fixes #33.