### PR TITLE
Better error visibility

### DIFF
--- a/carrot/src/background/background.js
+++ b/carrot/src/background/background.js
@@ -20,7 +20,7 @@ const RATINGS = new Ratings(api, LOCAL);
 const CONTESTS_COMPLETE = new ContestsComplete(api);
 const TOP_LEVEL_CACHE = new TopLevelCache();
 
-browser.runtime.onMessage.addListener((message) => {
+browser.runtime.onMessage.addListener((message, sender) => {
   let responsePromise;
   if (message.type === 'PREDICT') {
     console.info('Received message: %o', message);
@@ -28,6 +28,10 @@ browser.runtime.onMessage.addListener((message) => {
   } else if (message.type === 'PING') {
     console.info('Received message: %o', message);
     responsePromise = Promise.all([maybeUpdateContestList(), maybeUpdateRatings()]);
+  } else if (message.type === 'SET_ERROR_BADGE') {
+    console.info('Received message: %o', message);
+    setErrorBadge(sender);
+    responsePromise = Promise.resolve();
   } else {
     return;
   }
@@ -178,6 +182,17 @@ async function maybeUpdateRatings() {
 }
 
 // Cache related code ends.
+
+// Badge related code starts.
+
+function setErrorBadge(sender) {
+  const tabId = sender.tab.id;
+  browser.browserAction.setBadgeText({ text: '!', tabId });
+  browser.browserAction.setBadgeTextColor({ color: 'white', tabId });
+  browser.browserAction.setBadgeBackgroundColor({ color: 'hsl(355, 100%, 30%)', tabId });
+}
+
+// Badge related code ends.
 
 browser.runtime.onInstalled.addListener((details) => {
   if (details.previousVersion && compareVersions(details.previousVersion, '0.6.2') <= 0) {

--- a/carrot/src/background/background.js
+++ b/carrot/src/background/background.js
@@ -23,8 +23,10 @@ const TOP_LEVEL_CACHE = new TopLevelCache();
 browser.runtime.onMessage.addListener((message) => {
   let responsePromise;
   if (message.type === 'PREDICT') {
+    console.info('Received message: %o', message);
     responsePromise = getDeltas(message.contestId);
   } else if (message.type === 'PING') {
+    console.info('Received message: %o', message);
     responsePromise = Promise.all([maybeUpdateContestList(), maybeUpdateRatings()]);
   } else {
     return;

--- a/carrot/src/background/background.js
+++ b/carrot/src/background/background.js
@@ -188,7 +188,9 @@ async function maybeUpdateRatings() {
 function setErrorBadge(sender) {
   const tabId = sender.tab.id;
   browser.browserAction.setBadgeText({ text: '!', tabId });
-  browser.browserAction.setBadgeTextColor({ color: 'white', tabId });
+  if (browser.browserAction.setBadgeTextColor) {  // Only works in Firefox
+    browser.browserAction.setBadgeTextColor({ color: 'white', tabId });
+  }
   browser.browserAction.setBadgeBackgroundColor({ color: 'hsl(355, 100%, 30%)', tabId });
 }
 

--- a/carrot/src/background/cf-api.js
+++ b/carrot/src/background/cf-api.js
@@ -5,18 +5,27 @@
 const API_URL_PREFIX = 'https://codeforces.com/api/';
 
 async function apiFetch(path, queryParams) {
-  let url = new URL(API_URL_PREFIX + path);
+  const url = new URL(API_URL_PREFIX + path);
   for (const [key, value] of Object.entries(queryParams)) {
     if (value !== undefined) {
       url.searchParams.append(key, value);
     }
   }
   const resp = await fetch(url);
-  const json = await resp.json();
-  if (json.status === 'OK') {
-    return json.result;
+  const text = await resp.text();
+  if (resp.status !== 200) {
+    throw new Error(`CF API: HTTP error ${resp.status}: ${text}`)
   }
-  throw new Error(json.comment);
+  let json;
+  try {
+    json = JSON.parse(text);
+  } catch (_) {
+    throw new Error(`CF API: Invalid JSON: ${text}`);
+  }
+  if (json.status !== 'OK' || json.result === undefined) {
+    throw new Error(`CF API: Error: ${text}`);
+  }
+  return json.result;
 }
 
 export const contest = {

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -373,6 +373,7 @@ function main() {
       .catch(er => {
         console.error('[Carrot] Predict error: %o', er);
         state.error = er;
+        browser.runtime.sendMessage({ type: 'SET_ERROR_BADGE' });
       });
   }
 

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -48,8 +48,6 @@ const FINAL_COLUMNS = [
 ];
 const ALL_COLUMNS = PREDICT_COLUMNS.concat(FINAL_COLUMNS);
 
-let columns;  // Populated later
-
 function makeGreySpan(text, title) {
   const span = document.createElement('span');
   span.style.fontWeight = 'bold';
@@ -230,7 +228,7 @@ function populateCells(row, type, rankUpTint, perfCell, deltaCell, rankUpCell) {
 }
 
 function updateStandings(resp) {
-  let deltaColTitle, rankUpColWidth, rankUpColTitle;
+  let deltaColTitle, rankUpColWidth, rankUpColTitle, columns;
   switch (resp.type) {
     case 'FINAL':
       deltaColTitle = 'Final rating change';
@@ -285,6 +283,8 @@ function updateStandings(resp) {
       tableRow.appendChild(cell);
     }
   }
+
+  return columns;
 }
 
 function updateColumnVisibility(prefs) {
@@ -337,7 +337,7 @@ async function predict(contestId) {
     return;
   }
 
-  updateStandings(data.predictResponse);
+  const columns = updateStandings(data.predictResponse);
   switch (data.predictResponse.type) {
     case 'FINAL':
       showFinal();
@@ -349,7 +349,16 @@ async function predict(contestId) {
       throw new Error('Unknown prediction type: ' + data.predictResponse.type);
   }
   updateColumnVisibility(data.prefs);
+  return columns;
 }
+
+// Mutable state, set once.
+// If predict succeeds, columns will be set to either PREDICT_COLUMNS or FINAL_COLUMNS.
+// If it fails, error will be set to the received error.
+const state = {
+  columns: null,
+  error: null,
+};
 
 function main() {
   // On any Codeforces ranklist page.
@@ -357,8 +366,14 @@ function main() {
   const contestId = matches ? matches[1] : null;
   if (contestId && document.querySelector('table.standings')) {
     predict(contestId)
-      .then(() => console.info('[Carrot] Predict success'))
-      .catch(er => console.error('[Carrot] Predict error: %o', er));
+      .then(columns => {
+        console.info('[Carrot] Predict success');
+        state.columns = columns;
+      })
+      .catch(er => {
+        console.error('[Carrot] Predict error: %o', er);
+        state.error = er;
+      });
   }
 
   // On any Codeforces page.
@@ -374,7 +389,7 @@ main();
 
 browser.runtime.onMessage.addListener((message) => {
   if (message.type === 'LIST_COLS') {
-    return Promise.resolve(columns);
+    return Promise.resolve(state);
   } else if (message.type == 'UPDATE_COLS') {
     updateColumnVisibility(message.prefs);
     return Promise.resolve();

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -354,7 +354,7 @@ async function predict(contestId) {
 
 // Mutable state, set once.
 // If predict succeeds, columns will be set to either PREDICT_COLUMNS or FINAL_COLUMNS.
-// If it fails, error will be set to the received error.
+// If it fails, error will be set to the received error .toString().
 const state = {
   columns: null,
   error: null,
@@ -372,7 +372,7 @@ function main() {
       })
       .catch(er => {
         console.error('[Carrot] Predict error: %o', er);
-        state.error = er;
+        state.error = er.toString();
         browser.runtime.sendMessage({ type: 'SET_ERROR_BADGE' });
       });
   }

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -367,7 +367,6 @@ function main() {
   if (contestId && document.querySelector('table.standings')) {
     predict(contestId)
       .then(columns => {
-        console.info('[Carrot] Predict success');
         state.columns = columns;
       })
       .catch(er => {

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -377,10 +377,7 @@ function main() {
   }
 
   // On any Codeforces page.
-  const ping = () => {
-    browser.runtime.sendMessage({ type: 'PING' })
-      .catch(er => console.error('[Carrot] Background page ping error: %o', er));
-  };
+  const ping = () => { browser.runtime.sendMessage({ type: 'PING' }); };
   ping();
   setInterval(ping, PING_INTERVAL);
 }

--- a/carrot/src/content/content.js
+++ b/carrot/src/content/content.js
@@ -326,10 +326,10 @@ async function predict(contestId) {
   } catch (er) {
     switch (er.message) {
       case 'UNRATED_CONTEST':
-        console.info('Unrated contest, not displaying delta column.');
+        console.info('[Carrot] Unrated contest, not displaying delta column.');
         break;
       case 'DISABLED':
-        console.info('Deltas for this contest are disabled according to user settings.');
+        console.info('[Carrot] Deltas for this contest are disabled according to user settings.');
         break;
       default:
         throw er;
@@ -357,11 +357,15 @@ function main() {
   const contestId = matches ? matches[1] : null;
   if (contestId && document.querySelector('table.standings')) {
     predict(contestId)
-      .catch(er => console.error(er));
+      .then(() => console.info('[Carrot] Predict success'))
+      .catch(er => console.error('[Carrot] Predict error: %o', er));
   }
 
   // On any Codeforces page.
-  const ping = () => { browser.runtime.sendMessage({ type: 'PING' }); };
+  const ping = () => {
+    browser.runtime.sendMessage({ type: 'PING' })
+      .catch(er => console.error('[Carrot] Background page ping error: %o', er));
+  };
   ping();
   setInterval(ping, PING_INTERVAL);
 }

--- a/carrot/src/popup/popup.css
+++ b/carrot/src/popup/popup.css
@@ -125,6 +125,8 @@ input[type=checkbox]:checked::before {
   color: hsl(355, 100%, 30%);
   font-family: monospace;
   font-size: 13px;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 #error-footer {

--- a/carrot/src/popup/popup.css
+++ b/carrot/src/popup/popup.css
@@ -112,3 +112,25 @@ input[type=checkbox]:checked::before {
   transform: translate(10px);
 }
 /* Fancy toggle switch end */
+
+#error {
+  margin-top: 10px;
+  max-width: 250px;
+}
+
+#error-text {
+  padding: 8px 10px;
+  border-radius: 5px;
+  background-color: hsl(355, 100%, 40%, 0.15);
+  color: hsl(355, 100%, 30%);
+  font-family: monospace;
+  font-size: 13px;
+}
+
+#error-footer {
+  margin-top: 5px;
+  margin-left: 8px;
+  color: #555;
+  font-family: sans-serif;
+  font-size: 11px;
+}

--- a/carrot/src/popup/popup.html
+++ b/carrot/src/popup/popup.html
@@ -25,6 +25,10 @@
         </span>
       </div>
       <div id="options" style="display: none;"></div>
+      <div id="error" style="display: none;">
+        <div id="error-text"></div>
+        <div id="error-footer">For details, check the console.</div>
+      </div>
     </div>
   </body>
   <script type="module" src="popup.js"></script>

--- a/carrot/src/popup/popup.js
+++ b/carrot/src/popup/popup.js
@@ -55,7 +55,7 @@ function trimString(s, n) {
 }
 
 function showError(err) {
-  const errTrimmed = trimString(err.toString(), ERROR_STR_MAX_LEN);
+  const errTrimmed = trimString(err, ERROR_STR_MAX_LEN);
   const errorTextDiv = document.querySelector('#error-text');
   errorTextDiv.textContent = errTrimmed;
 

--- a/carrot/src/popup/popup.js
+++ b/carrot/src/popup/popup.js
@@ -1,6 +1,10 @@
 import * as settings from '../util/settings.js';
 import UserPrefs from '../util/user-prefs.js';
 
+const Unicode = {
+  HORIZONTAL_ELLIPSIS: '\u2026',
+};
+
 async function makeList(cols, changeCallback) {
   const ul = document.createElement('ul');
   for (const col of cols) {
@@ -41,6 +45,24 @@ async function informAllTabs() {
   }
 }
 
+const ERROR_STR_MAX_LEN = 100;
+
+function trimString(s, n) {
+  if (s.length <= n) {
+    return s;
+  }
+  return s.substring(0, n-1) + Unicode.HORIZONTAL_ELLIPSIS;
+}
+
+function showError(err) {
+  const errTrimmed = trimString(err.toString(), ERROR_STR_MAX_LEN);
+  const errorTextDiv = document.querySelector('#error-text');
+  errorTextDiv.textContent = errTrimmed;
+
+  const errorDiv = document.querySelector('#error');
+  errorDiv.style.display = null;  // Make visible
+}
+
 async function setup() {
   const manifest = browser.runtime.getManifest();
 
@@ -62,12 +84,15 @@ async function setup() {
   let tabColumns;
   try {
     tabColumns = await browser.tabs.sendMessage(tab.id, { type: 'LIST_COLS' });
-  } catch (e) {
+  } catch (_) {
     // No listener on the tab
     return;
   }
-  if (tabColumns) {
-    await makeList(tabColumns, informAllTabs);
+  if (tabColumns.columns) {
+    await makeList(tabColumns.columns, informAllTabs);
+  }
+  if (tabColumns.error) {
+    showError(tabColumns.error);
   }
 }
 

--- a/carrot/src/popup/popup.js
+++ b/carrot/src/popup/popup.js
@@ -45,7 +45,7 @@ async function informAllTabs() {
   }
 }
 
-const ERROR_STR_MAX_LEN = 100;
+const ERROR_STR_MAX_LEN = 120;
 
 function trimString(s, n) {
   if (s.length <= n) {

--- a/carrot/src/popup/popup.js
+++ b/carrot/src/popup/popup.js
@@ -90,9 +90,10 @@ async function setup() {
   }
   if (tabColumns.columns) {
     await makeList(tabColumns.columns, informAllTabs);
-  }
-  if (tabColumns.error) {
+  } else if (tabColumns.error) {
     showError(tabColumns.error);
+  } else {
+    // Unreachable
   }
 }
 


### PR DESCRIPTION
Fixes #43
- Better handling of CF API errors. When disabled by the CF admins, CF API does not serve valid JSON and neither does it use appropriate HTTP error codes, it just serves an HTML error page with status 200. Carrot now catches errors if JSON conversion fails and wraps it appropriately.
- Better console logging of errors. Errors message are now clearly prefix with `[Carrot]` which should let users more easily see what went wrong.
- The extension icon now indicates if there is an error on the ranklist page with a red "!".
- Clicking on it, the popup shows the error message, or a prefix of it if it's too long.