### PR TITLE
Support Chrome Manifest V3

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -110,14 +110,12 @@ pack_chrome() {
 
   # Set png icons in the manifest.
   jq_manifest_replace ".icons = ${icons_json} |
-      .browser_action.default_icon = \"icons/icon${icon_sizes[-1]}.png\"" manifest.json
+      .action.default_icon = \"icons/icon${icon_sizes[2]}.png\"" manifest.json
 
   # Final touches to manifest.json.
   jq_manifest_replace 'del(.browser_specific_settings) |
-      if .options_ui.browser_style
-        then .options_ui.chrome_style = .options_ui.browser_style else . end |
       del (.options_ui.browser_style) |
-      del (.browser_action.browser_style)' manifest.json
+      del (.action.browser_style)' manifest.json
 
   if [[ -n "${release_dir}" ]]; then
     # Prepare the zip.

--- a/carrot/manifest.json
+++ b/carrot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Carrot",
   "version": "0.6.7",
   "description": "Rating predictor for Codeforces",
@@ -10,12 +10,14 @@
   },
   "permissions": [
     "storage",
-    "unlimitedStorage",
+    "unlimitedStorage"
+  ],
+  "host_permissions": [
     "*://*.codeforces.com/*"
   ],
   "background": {
-    "page": "src/background/background.html",
-    "persistent": true
+    "service_worker": "src/background/background.js",
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -28,8 +30,7 @@
     "page": "src/options/options.html",
     "browser_style": true
   },
-  "browser_action": {
-    "browser_style": true,
+  "action": {
     "default_icon": "icons/icon.svg",
     "default_title": "Carrot",
     "default_popup": "src/popup/popup.html"

--- a/carrot/src/background/background.html
+++ b/carrot/src/background/background.html
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <script type="module" src="background.js"></script>
-  </head>
-</html>

--- a/carrot/src/background/background.js
+++ b/carrot/src/background/background.js
@@ -8,6 +8,7 @@ import predict, { Contestant, PredictResult } from './predict.js';
 import PredictResponse from './predict-response.js';
 import { Api } from './cf-api.js';
 import compareVersions from '../util/version-compare.js';
+import '../../polyfill/browser-polyfill.min.js'
 
 const DEBUG_FORCE_PREDICT = false;
 


### PR DESCRIPTION
> Changing to manifest V3 is a bunch of annoying work and for no good reason.

Solved #69. With AI Coding like Windsurf, it is much easier than I thought. New mainfest fields are handled very well. Tested in Chrome and it works for me.


