### PR TITLE
Migrate extension from Manifest V2 to V3

### DIFF
--- a/carrot/manifest.json
+++ b/carrot/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Carrot",
   "version": "0.6.7",
   "description": "Rating predictor for Codeforces",
@@ -11,11 +11,14 @@
   "permissions": [
     "storage",
     "unlimitedStorage",
+    "tabs"
+  ],
+  "host_permissions": [
     "*://*.codeforces.com/*"
   ],
   "background": {
-    "page": "src/background/background.html",
-    "persistent": true
+    "service_worker": "src/background/background.js",
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -26,17 +29,11 @@
   ],
   "options_ui": {
     "page": "src/options/options.html",
-    "browser_style": true
+    "open_in_tab": true
   },
-  "browser_action": {
-    "browser_style": true,
+  "action": {
     "default_icon": "icons/icon.svg",
     "default_title": "Carrot",
     "default_popup": "src/popup/popup.html"
-  },
-  "browser_specific_settings": {
-    "gecko": {
-      "id": "testid@testdomain.com"
-    }
   }
 }

--- a/carrot/src/popup/popup.js
+++ b/carrot/src/popup/popup.js
@@ -36,8 +36,8 @@ async function makeList(cols, changeCallback) {
 
 async function informAllTabs() {
   const prefs = await settings.getPrefs();
-  for (const tab of await browser.tabs.query({})) {
-    browser.tabs.sendMessage(tab.id, {
+  for (const tab of await chrome.tabs.query({})) {
+    chrome.tabs.sendMessage(tab.id, {
       type: 'UPDATE_COLS',
       prefs,
     }).catch(() => { /* No listener on this tab */ });
@@ -63,26 +63,26 @@ function showError(err) {
 }
 
 async function setup() {
-  const manifest = browser.runtime.getManifest();
+  const manifest = chrome.runtime.getManifest();
 
   document.querySelector('#version').textContent = 'v' + manifest.version;
   document.querySelector('#title').textContent = manifest.name;
   document.querySelector('#icon').src =
-    browser.runtime.getURL(manifest.browser_action.default_icon);
+    chrome.runtime.getURL(manifest.action.default_icon);
 
   const settings = document.querySelector('#settings');
   settings.addEventListener('click', () => {
-    browser.runtime.openOptionsPage();
+    chrome.runtime.openOptionsPage();
     window.close();
   });
 
-  const [tab] = await browser.tabs.query({
+  const [tab] = await chrome.tabs.query({
     active: true,
     currentWindow: true,
   });
   let tabColumns;
   try {
-    tabColumns = await browser.tabs.sendMessage(tab.id, { type: 'LIST_COLS' });
+    tabColumns = await chrome.tabs.sendMessage(tab.id, { type: 'LIST_COLS' });
   } catch (_) {
     // No listener on the tab
     return;

--- a/carrot/src/util/storage-wrapper.js
+++ b/carrot/src/util/storage-wrapper.js
@@ -1,5 +1,5 @@
 /**
- * Convenience wrapper around browser.storage.
+ * Convenience wrapper around chrome.storage.
  */
 class StorageWrapper {
   constructor(storageName) {
@@ -7,13 +7,13 @@ class StorageWrapper {
   }
 
   async get(key, defaultValue) {
-    const obj = await browser.storage[this.storageName].get(key);
+    const obj = await chrome.storage[this.storageName].get(key);
     const value = obj[key];
     return value !== undefined ? value : defaultValue;
   }
 
   async set(key, value) {
-    return await browser.storage[this.storageName].set({ [key]: value });
+    return await chrome.storage[this.storageName].set({ [key]: value });
   }
 }
 


### PR DESCRIPTION
This commit updates the browser extension to use Manifest V3 specifications with the following key changes:

- Update manifest.json to version 3
- Replace background page with service worker
- Migrate browser.* APIs to chrome.* APIs
- Add connection handling and keepalive mechanism
- Update permissions structure (split into host_permissions)
- Improve error handling and connection reliability
- Replace browser_action with action
- Remove Firefox-specific settings

Technical changes:
- Add port-based messaging system for reliable communication
- Implement connection check and auto-reconnect logic
- Add session-based reload limiting
- Enhance error handling in content scripts

Screenshot for the working extension: ![Screenshot 2025-03-01 144755](https://github.com/user-attachments/assets/826f9758-a773-4928-bed9-3ae73939c867)
